### PR TITLE
feat: Improve message associated with cython custom command

### DIFF
--- a/src/cython_cmake/cmake/UseCython.cmake
+++ b/src/cython_cmake/cmake/UseCython.cmake
@@ -125,10 +125,15 @@ function(Cython_compile_pyx)
     set(_depfile ${generated_file}.dep)
     set(_depfile_arg "-M")
 
+    # Normalize the input path
+    get_filename_component(_source_file "${_source_file}" ABSOLUTE)
+
+    # Pretty-printed output names
     file(RELATIVE_PATH generated_file_relative
         ${CMAKE_BINARY_DIR} ${generated_file})
-
-    set(comment "Generating ${_language} source ${generated_file_relative}")
+    file(RELATIVE_PATH source_file_relative
+        ${CMAKE_SOURCE_DIR} ${_source_file})
+    set(comment "Generating ${_language} source '${generated_file_relative}' from '${source_file_relative}'")
 
     get_source_file_property(pyx_location ${_source_file} LOCATION)
 


### PR DESCRIPTION
Integrate changes originally introduced through:
* https://github.com/scikit-build/cython-cmake/pull/19

Before:

```
$ make
[...]
[ 33%] Generating C source simple.c
[ 66%] Building C object CMakeFiles/simple.dir/simple.c.o
[100%] Linking C shared module simple.cpython-39-x86_64-linux-gnu.so
[100%] Built target simple

```

After:

```
$ make
[...]
[ 33%] Generating C source 'simple.c' from 'simple.pyx'
[ 66%] Building C object CMakeFiles/simple.dir/simple.c.o
[100%] Linking C shared module simple.cpython-39-x86_64-linux-gnu.so
[100%] Built target simple
```
