### PR TITLE
refactor: Rename `cython_compile_pyx` to `cython_transpile`

### DIFF
--- a/src/cython_cmake/cmake/UseCython.cmake
+++ b/src/cython_cmake/cmake/UseCython.cmake
@@ -2,16 +2,16 @@
 #
 # The following functions are defined:
 #
-# .. cmake:command:: Cython_compile_pyx
+# .. cmake:command:: Cython_transpile
 #
 # Create custom rules to generate the source code for a Python extension module
 # using cython.
 #
-#   Cython_compile_pyx(<pyx_file>
-#                     [LANGUAGE C | CXX]
-#                     [CYTHON_ARGS <args> ...]
-#                     [OUTPUT <OutputFile>]
-#                     [OUTPUT_VARIABLE <OutputVariable>])
+#   Cython_transpile(<pyx_file>
+#                   [LANGUAGE C | CXX]
+#                   [CYTHON_ARGS <args> ...]
+#                   [OUTPUT <OutputFile>]
+#                   [OUTPUT_VARIABLE <OutputVariable>])
 #
 # Options:
 #
@@ -44,7 +44,7 @@
 #   find_package(Cython)
 #   include(UseCython)
 #
-#   Cython_compile_pyx(_hello.pyx
+#   Cython_transpile(_hello.pyx
 #     OUTPUT_VARIABLE _hello_source_files
 #   )
 #
@@ -76,7 +76,7 @@ if(CMAKE_VERSION VERSION_LESS "3.8")
   message(FATAL_ERROR "CMake 3.8 required for COMMAND_EXPAND_LISTS")
 endif()
 
-function(Cython_compile_pyx)
+function(Cython_transpile)
   set(_options )
   set(_one_value LANGUAGE OUTPUT OUTPUT_VARIABLE)
   set(_multi_value CYTHON_ARGS)
@@ -110,14 +110,14 @@ function(Cython_compile_pyx)
     message(FATAL_ERROR "One and only one input file must be specified, got '${_source_files}'")
   endif()
 
-  function(_compile_pyx _source_file generated_file language)
+  function(_transpile _source_file generated_file language)
 
     if(language STREQUAL "C")
       set(_language_arg "")
     elseif(language STREQUAL "CXX")
       set(_language_arg "--cplus")
     else()
-      message(FATAL_ERROR "_compile_pyx language must be one of C or CXX")
+      message(FATAL_ERROR "_transpile language must be one of C or CXX")
     endif()
 
     set_source_files_properties(${generated_file} PROPERTIES GENERATED TRUE)
@@ -215,7 +215,7 @@ function(Cython_compile_pyx)
   endif()
 
   if(NOT _language MATCHES "^(C|CXX)$")
-    message(FATAL_ERROR "cython_compile_pyx LANGUAGE must be one of C or CXX")
+    message(FATAL_ERROR "Cython_transpile LANGUAGE must be one of C or CXX")
   endif()
 
   # Place the cython files in the current binary dir if no path given
@@ -226,7 +226,7 @@ function(Cython_compile_pyx)
   endif()
 
   set(generated_file ${_args_OUTPUT})
-  _compile_pyx(${_source_file} ${generated_file} ${_language})
+  _transpile(${_source_file} ${generated_file} ${_language})
   list(APPEND generated_files ${generated_file})
 
   # Output variable only if set

--- a/tests/packages/multiple_packages/CMakeLists.txt
+++ b/tests/packages/multiple_packages/CMakeLists.txt
@@ -10,7 +10,7 @@ include(UseCython)
 
 #-----------------------------------------------------------------------------
 # package1.module
-cython_compile_pyx(package1/module.pyx
+cython_transpile(package1/module.pyx
   LANGUAGE C
   OUTPUT_VARIABLE module_c
 )
@@ -21,7 +21,7 @@ install(TARGETS module1 DESTINATION "package1")
 
 #-----------------------------------------------------------------------------
 # package1.package2.module
-cython_compile_pyx(package1/package2/module.pyx
+cython_transpile(package1/package2/module.pyx
   LANGUAGE C
   OUTPUT_VARIABLE module_c
 )
@@ -35,7 +35,7 @@ install(TARGETS module2 DESTINATION "package1/package2")
 
 file(COPY package1/package2/module.pyx DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-cython_compile_pyx(${CMAKE_CURRENT_SOURCE_DIR}/../module.pyx
+cython_transpile(${CMAKE_CURRENT_SOURCE_DIR}/../module.pyx
   LANGUAGE C
   CYTHON_ARGS
     --module-name "package1.package3.module"

--- a/tests/packages/simple/CMakeLists.txt
+++ b/tests/packages/simple/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(
 find_package(Cython MODULE REQUIRED VERSION 3.0)
 include(UseCython)
 
-cython_compile_pyx(simple.pyx
+cython_transpile(simple.pyx
   LANGUAGE C
   # PLACEHOLDER
   OUTPUT_VARIABLE simple_c


### PR DESCRIPTION
The verb "transpile" more accurately describes the role of the function, as it is used to convert Cython (or Python) code to C/C++ code rather than directly compiling it. This change aligns the function name with its intended purpose.