### PR TITLE
Fix VERSION_VAR in FindCython.cmake

### DIFF
--- a/src/cython_cmake/cmake/FindCython.cmake
+++ b/src/cython_cmake/cmake/FindCython.cmake
@@ -97,7 +97,7 @@ endif()
 
 find_package_handle_standard_args(Cython
   REQUIRED_VARS CYTHON_EXECUTABLE
-  VERSION_VAR ${CYTHON_VERSION}
+  VERSION_VAR CYTHON_VERSION
   ${_handle_version_range}
 )
 


### PR DESCRIPTION
This needs to be the name of the var. Not the value.