### PR TITLE
test: add C++ library wrapping example

### DIFF
--- a/tests/packages/cpp_library/.gitignore
+++ b/tests/packages/cpp_library/.gitignore
@@ -1,0 +1,176 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python

--- a/tests/packages/cpp_library/CMakeLists.txt
+++ b/tests/packages/cpp_library/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.15...3.29)
+project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX)
+
+find_package(
+  Python
+  COMPONENTS Interpreter Development.Module
+  REQUIRED)
+find_package(Cython MODULE REQUIRED VERSION 3.0)
+include(UseCython)
+
+# A C++ library you build yourself. This could equally be brought in with
+# add_subdirectory() or find_package() for an external library.
+add_library(mylib STATIC mylib.cpp)
+target_include_directories(mylib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+# Needed so the static library can be linked into the shared extension module.
+set_target_properties(mylib PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# Transpile the Cython wrapper to C++ ...
+cython_transpile(wrapper.pyx
+  LANGUAGE CXX
+  OUTPUT_VARIABLE wrapper_cxx
+)
+
+# ... then build it into an extension module linked against the C++ library.
+python_add_library(wrapper MODULE "${wrapper_cxx}" WITH_SOABI)
+target_link_libraries(wrapper PRIVATE mylib)
+
+install(TARGETS wrapper DESTINATION .)

--- a/tests/packages/cpp_library/main.fmf
+++ b/tests/packages/cpp_library/main.fmf
@@ -1,0 +1,1 @@
+summary: Cython wrapper linked against a C++ library

--- a/tests/packages/cpp_library/mylib.cpp
+++ b/tests/packages/cpp_library/mylib.cpp
@@ -1,0 +1,5 @@
+#include "mylib.hpp"
+
+Multiplier::Multiplier(int factor) : factor_(factor) {}
+
+int Multiplier::compute(int value) const { return factor_ * value; }

--- a/tests/packages/cpp_library/mylib.hpp
+++ b/tests/packages/cpp_library/mylib.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+// A small C++ library, standing in for one you build yourself or pull in with
+// add_subdirectory()/find_package().
+class Multiplier {
+public:
+  explicit Multiplier(int factor);
+  int compute(int value) const;
+
+private:
+  int factor_;
+};

--- a/tests/packages/cpp_library/pyproject.toml
+++ b/tests/packages/cpp_library/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["scikit-build-core", "cython", "cython-cmake"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "example"
+version = "0.0.1"

--- a/tests/packages/cpp_library/wrapper.pyx
+++ b/tests/packages/cpp_library/wrapper.pyx
@@ -1,0 +1,20 @@
+# cython: language_level=3
+# distutils: language = c++
+
+cdef extern from "mylib.hpp":
+    cdef cppclass Multiplier:
+        Multiplier(int)
+        int compute(int)
+
+
+cdef class PyMultiplier:
+    cdef Multiplier* _c
+
+    def __cinit__(self, int factor):
+        self._c = new Multiplier(factor)
+
+    def __dealloc__(self):
+        del self._c
+
+    def compute(self, int value):
+        return self._c.compute(value)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -189,6 +189,25 @@ def test_depends_generated_pxd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     assert "simple.c" in build_files
 
 
+def test_cpp_library(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(DIR / "packages/cpp_library")
+    build_dir = tmp_path / "build"
+
+    # The .pyx wraps a C++ class from a library built in the same project; the
+    # extension module is linked against that library via target_link_libraries.
+    wheel = build_wheel(
+        str(tmp_path), {"build-dir": str(build_dir), "wheel.license-files": []}
+    )
+
+    with zipfile.ZipFile(tmp_path / wheel) as f:
+        file_names = set(f.namelist())
+    assert len(file_names) == 4
+
+    build_files = {x.name for x in build_dir.iterdir()}
+    assert "wrapper.cxx.dep" in build_files
+    assert "wrapper.cxx" in build_files
+
+
 def test_genex_cython_args(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capfd: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Addresses #66 — "how do I wrap a C++ library with Cython?"

Adds a worked, tested example under `tests/packages/cpp_library` showing the full flow:

- a small C++ library built with `add_library` (stand-in for your own or an external one)
- a `.pyx` wrapper declaring the C++ class via `cdef extern` and exposing a `cdef class`
- `cython_transpile(... LANGUAGE CXX)` to emit C++, then `python_add_library` + `target_link_libraries` to link the extension module against the library

`test_cpp_library` drives a real `build_wheel`, so the compile **and** link are exercised — a broken link line would fail the build. Verified the wrapped class is callable at runtime (`PyMultiplier(3).compute(4) == 12`).

Full `test_package.py` suite passes and `prek -a` is clean.
