### PR TITLE
chore: mark Beta and use dependency-groups for hatch-test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 license.file = "LICENSE"
 requires-python = ">=3.8"
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Science/Research",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
@@ -65,7 +65,7 @@ build.hooks.vcs.version-file = "src/cython_cmake/_version.py"
 installer = "uv"
 
 [tool.hatch.envs.hatch-test]
-features = ["test"]
+dependency-groups = ["test"]
 extra-dependencies = ["cmake", "ninja"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Two small housekeeping changes:

- Bump the development status classifier from `3 - Alpha` to `4 - Beta`.
- Switch the `hatch-test` environment from the (now removed) `test` extra to the existing PEP 735 `test` dependency group, matching how the project already declares its test deps under `[dependency-groups]`.
